### PR TITLE
Add unittests for data processing and update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pynvml
 scipy
 torch
 transformers
+pytest

--- a/tests/test_process_experiment_data.py
+++ b/tests/test_process_experiment_data.py
@@ -1,0 +1,39 @@
+import unittest
+
+try:
+    import pandas as pd
+except Exception:
+    pd = None
+
+class MergeDataTest(unittest.TestCase):
+    def setUp(self):
+        if pd is None:
+            self.skipTest('pandas not available')
+
+    def test_merge_with_tolerance(self):
+        from process_experiment_data import merge_data, MERGE_TOLERANCE
+        main_df = pd.DataFrame({
+            'timestamp': [
+                pd.Timestamp('2023-01-01 00:00:03'),
+                pd.Timestamp('2023-01-01 00:00:10'),
+                pd.Timestamp('2023-01-01 00:00:11')
+            ],
+            'value': [1, 2, 3]
+        })
+
+        additional_df = pd.DataFrame({
+            'timestamp': [
+                pd.Timestamp('2023-01-01 00:00:00'),
+                pd.Timestamp('2023-01-01 00:00:05')
+            ],
+            'extra': ['a', 'b']
+        })
+
+        merged = merge_data(main_df, additional_df, tolerance=MERGE_TOLERANCE)
+
+        self.assertEqual(merged.loc[0, 'extra'], 'a')
+        self.assertEqual(merged.loc[1, 'extra'], 'b')
+        self.assertTrue(pd.isna(merged.loc[2, 'extra']))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -1,0 +1,24 @@
+import unittest
+
+try:
+    import pandas as pd
+except Exception:
+    pd = None
+
+class RecommendSweetSpotTest(unittest.TestCase):
+    def setUp(self):
+        if pd is None:
+            self.skipTest('pandas not available')
+
+    def test_recommend_selects_min_energy_row(self):
+        from recommend import recommend_sweet_spot
+        df = pd.DataFrame({
+            'max_watt': [150, 200, 250],
+            'energy_consumption_watt_min': [100.0, 80.0, 120.0]
+        }).set_index('max_watt')
+
+        result = recommend_sweet_spot(df)
+        self.assertEqual(result, 200)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add small unit tests covering recommendation and merging logic
- skip tests when pandas is unavailable
- include pytest in requirements

## Testing
- `python -m unittest discover -s tests -v`
- `python -m pytest -q` *(fails: No module named pytest)*